### PR TITLE
fix: resolve unknown plugin source in hook profiler

### DIFF
--- a/inc/class-callback-wrapper.php
+++ b/inc/class-callback-wrapper.php
@@ -25,14 +25,15 @@ class WP_Hook_Profiler_Callback_Wrapper {
         
         if (!isset($this->engine->callback_aggregates[$callback_key])) {
             $this->engine->callback_aggregates[$callback_key] = [
-                'hook' => $this->hook_name,
-                'callback' => $callback_name,
-                'plugin' => $plugin_info['plugin'],
-                'source_file' => $plugin_info['file'],
-                'total_time' => 0,
-                'call_count' => 0,
-                'average_time' => 0,
-                'priority' => $this->priority,
+                'hook'          => $this->hook_name,
+                'callback'      => $callback_name,
+                'plugin'        => $plugin_info['plugin'],
+                'plugin_name'   => $plugin_info['plugin_name'],
+                'source_file'   => $plugin_info['file'],
+                'total_time'    => 0,
+                'call_count'    => 0,
+                'average_time'  => 0,
+                'priority'      => $this->priority,
                 'accepted_args' => $this->accepted_args
             ];
         }

--- a/inc/class-plugin-detector.php
+++ b/inc/class-plugin-detector.php
@@ -7,18 +7,52 @@ class WP_Hook_Profiler_Plugin_Detector {
     private $plugins_cache = null;
     private $themes_cache = null;
     private $wp_core_path = null;
+
+    /**
+     * Resolved (real) path of WP_PLUGIN_DIR, used for symlink-safe comparisons.
+     *
+     * @var string
+     */
+    private $real_plugin_dir = null;
+
+    /**
+     * Resolved (real) path of WPMU_PLUGIN_DIR, used for symlink-safe comparisons.
+     *
+     * @var string
+     */
+    private $real_mu_plugin_dir = null;
     
     public function __construct() {
-        $this->wp_core_path = ABSPATH . 'wp-includes/';
+        $this->wp_core_path    = ABSPATH . 'wp-includes/';
+        $this->real_plugin_dir = $this->normalize_path( WP_PLUGIN_DIR );
+        // WPMU_PLUGIN_DIR may not be defined on non-multisite installs.
+        $this->real_mu_plugin_dir = defined( 'WPMU_PLUGIN_DIR' )
+            ? $this->normalize_path( WPMU_PLUGIN_DIR )
+            : null;
+    }
+
+    /**
+     * Normalize a filesystem path: resolve symlinks when possible, ensure no
+     * trailing slash, and use forward slashes.
+     *
+     * @param string $path
+     * @return string
+     */
+    private function normalize_path( $path ) {
+        $real = realpath( $path );
+        if ( $real !== false ) {
+            return rtrim( str_replace( '\\', '/', $real ), '/' );
+        }
+        return rtrim( str_replace( '\\', '/', $path ), '/' );
     }
     
     public function identify_callback_source($callback) {
         $source_info = [
-            'plugin' => 'wordpress-core',
+            'plugin'      => 'wordpress-core',
             'plugin_name' => 'WordPress Core',
             'plugin_file' => null,
-            'file' => null,
-            'line' => null
+            'file'        => null,
+            'line'        => null
         ];
         
         try {
@@ -29,26 +63,36 @@ class WP_Hook_Profiler_Plugin_Detector {
             }
             
             $filename = $reflection->getFileName();
-            $line = $reflection->getStartLine();
+            $line     = $reflection->getStartLine();
             
             if (!$filename) {
                 return $this->unknown_source();
             }
+
+            // Normalize the filename so symlink-based paths compare correctly.
+            $filename_normalized = $this->normalize_path( $filename );
             
             $source_info['file'] = $filename;
             $source_info['line'] = $line;
-            
-            $plugin_info = $this->match_file_to_plugin($filename);
+
+            // Check mu-plugins first so they are attributed to their own plugin
+            // rather than falling through to the WordPress Core bucket.
+            $mu_info = $this->match_file_to_mu_plugin( $filename_normalized );
+            if ( $mu_info ) {
+                return array_merge( $source_info, $mu_info );
+            }
+
+            $plugin_info = $this->match_file_to_plugin( $filename_normalized );
             if ($plugin_info) {
                 return array_merge($source_info, $plugin_info);
             }
             
-            $theme_info = $this->match_file_to_theme($filename);
+            $theme_info = $this->match_file_to_theme( $filename_normalized );
             if ($theme_info) {
                 return array_merge($source_info, $theme_info);
             }
             
-            if ($this->is_wordpress_core($filename)) {
+            if ($this->is_wordpress_core( $filename_normalized )) {
                 return $source_info;
             }
             
@@ -66,7 +110,7 @@ class WP_Hook_Profiler_Plugin_Detector {
                     return new ReflectionFunction($callback);
                 }
             } elseif (is_array($callback) && count($callback) === 2) {
-                $class = $callback[0];
+                $class  = $callback[0];
                 $method = $callback[1];
                 
                 if (is_object($class)) {
@@ -89,43 +133,83 @@ class WP_Hook_Profiler_Plugin_Detector {
         
         return null;
     }
+
+    /**
+     * Match a normalized filename against mu-plugins.
+     *
+     * mu-plugins are NOT WordPress Core — they are site-specific or third-party
+     * code that happens to be loaded as must-use plugins.
+     *
+     * @param string $filename_normalized Normalized absolute path.
+     * @return array|null Source info array, or null if not an mu-plugin file.
+     */
+    private function match_file_to_mu_plugin( $filename_normalized ) {
+        if ( $this->real_mu_plugin_dir === null ) {
+            return null;
+        }
+
+        if ( strpos( $filename_normalized, $this->real_mu_plugin_dir . '/' ) !== 0 ) {
+            return null;
+        }
+
+        try {
+            $relative  = substr( $filename_normalized, strlen( $this->real_mu_plugin_dir ) + 1 );
+            $parts     = explode( '/', $relative );
+            $slug      = pathinfo( $parts[0], PATHINFO_FILENAME );
+            $name      = ucwords( str_replace( [ '-', '_' ], ' ', $slug ) );
+
+            return [
+                'plugin'      => 'mu-' . $slug,
+                'plugin_name' => $name . ' (MU)',
+                'plugin_file' => null,
+            ];
+        } catch ( Exception $e ) {
+            return null;
+        }
+    }
     
-    private function match_file_to_plugin($filename) {
+    private function match_file_to_plugin( $filename_normalized ) {
         $plugins = $this->get_plugins_data();
         
         foreach ($plugins as $plugin_file => $plugin_data) {
             try {
-                $plugin_dir = dirname(WP_PLUGIN_DIR . '/' . $plugin_file);
-
-                if (!str_contains($plugin_file, '/')) {
-                    if ($filename === $plugin_file) {
+                if ( strpos( $plugin_file, '/' ) === false ) {
+                    // Single-file plugin (e.g. "hello.php") — compare full absolute path.
+                    $abs_plugin_file = $this->normalize_path( WP_PLUGIN_DIR . '/' . $plugin_file );
+                    if ( $filename_normalized === $abs_plugin_file ) {
                         return [
-                            'plugin' => $this->get_plugin_slug($plugin_file),
+                            'plugin'      => $this->get_plugin_slug($plugin_file),
                             'plugin_name' => $this->safe_get_plugin_name($plugin_data, $plugin_file),
                             'plugin_file' => $plugin_file
                         ];
                     }
-                } else if (strpos($filename, $plugin_dir) === 0) {
-                    return [
-                        'plugin' => $this->get_plugin_slug($plugin_file),
-                        'plugin_name' => $this->safe_get_plugin_name($plugin_data, $plugin_file),
-                        'plugin_file' => $plugin_file
-                    ];
+                } else {
+                    // Directory-based plugin — check if the file lives inside the plugin dir.
+                    $plugin_dir = $this->normalize_path( WP_PLUGIN_DIR . '/' . dirname( $plugin_file ) );
+                    if ( strpos( $filename_normalized, $plugin_dir . '/' ) === 0 ) {
+                        return [
+                            'plugin'      => $this->get_plugin_slug($plugin_file),
+                            'plugin_name' => $this->safe_get_plugin_name($plugin_data, $plugin_file),
+                            'plugin_file' => $plugin_file
+                        ];
+                    }
                 }
             } catch (Exception $e) {
                 // Skip this plugin if there's an error processing it
                 continue;
             }
         }
-        
-        if (strpos($filename, WP_PLUGIN_DIR) === 0) {
+
+        // Fallback: file is inside WP_PLUGIN_DIR but wasn't matched to a registered plugin
+        // (e.g. inactive plugin, or get_plugins() returned stale data).
+        if ( strpos( $filename_normalized, $this->real_plugin_dir . '/' ) === 0 ) {
             try {
-                $relative_path = str_replace(WP_PLUGIN_DIR . '/', '', $filename);
-                $path_parts = explode('/', $relative_path);
+                $relative    = substr( $filename_normalized, strlen( $this->real_plugin_dir ) + 1 );
+                $path_parts  = explode( '/', $relative );
                 $plugin_slug = $path_parts[0];
                 
                 return [
-                    'plugin' => $plugin_slug,
+                    'plugin'      => $plugin_slug,
                     'plugin_name' => ucwords(str_replace(['-', '_'], ' ', $plugin_slug)),
                     'plugin_file' => null
                 ];
@@ -137,24 +221,24 @@ class WP_Hook_Profiler_Plugin_Detector {
         return null;
     }
     
-    private function match_file_to_theme($filename) {
+    private function match_file_to_theme( $filename_normalized ) {
         try {
-            $theme_root = get_theme_root();
+            $theme_root      = $this->normalize_path( get_theme_root() );
             
-            if (strpos($filename, $theme_root) === 0) {
-                $relative_path = str_replace($theme_root . '/', '', $filename);
-                $theme_slug = explode('/', $relative_path)[0];
+            if ( strpos( $filename_normalized, $theme_root . '/' ) === 0 ) {
+                $relative   = substr( $filename_normalized, strlen( $theme_root ) + 1 );
+                $theme_slug = explode('/', $relative)[0];
                 
                 try {
-                    $theme = wp_get_theme($theme_slug);
+                    $theme      = wp_get_theme($theme_slug);
                     $theme_name = $theme->exists() ? $theme->get('Name') : ucwords(str_replace(['-', '_'], ' ', $theme_slug));
                 } catch (Exception $e) {
                     $theme_name = ucwords(str_replace(['-', '_'], ' ', $theme_slug));
                 }
                 
                 return [
-                    'plugin' => 'theme-' . $theme_slug,
-                    'plugin_name' => $theme_name,
+                    'plugin'      => 'theme-' . $theme_slug,
+                    'plugin_name' => $theme_name . ' (Theme)',
                     'plugin_file' => null
                 ];
             }
@@ -165,10 +249,19 @@ class WP_Hook_Profiler_Plugin_Detector {
         return null;
     }
     
-    private function is_wordpress_core($filename) {
-        return strpos($filename, $this->wp_core_path) === 0 ||
-               strpos($filename, ABSPATH . 'wp-admin/') === 0 ||
-               strpos($filename, ABSPATH . 'wp-content/mu-plugins/') === 0;
+    private function is_wordpress_core( $filename_normalized ) {
+        $core_paths = [
+            $this->normalize_path( ABSPATH . 'wp-includes' ) . '/',
+            $this->normalize_path( ABSPATH . 'wp-admin' ) . '/',
+        ];
+
+        foreach ( $core_paths as $core_path ) {
+            if ( strpos( $filename_normalized, $core_path ) === 0 ) {
+                return true;
+            }
+        }
+
+        return false;
     }
     
     private function get_plugins_data() {
@@ -181,18 +274,15 @@ class WP_Hook_Profiler_Plugin_Detector {
                 require_once ABSPATH . 'wp-admin/includes/plugin.php';
             }
             
-            $all_plugins = get_plugins();
+            $all_plugins         = get_plugins();
             $this->plugins_cache = [];
             
-            // Filter out plugins with invalid data structures
             foreach ($all_plugins as $plugin_file => $plugin_data) {
                 try {
-                    // Test if we can safely access the plugin data
                     if (is_array($plugin_data)) {
                         $this->plugins_cache[$plugin_file] = $plugin_data;
                     }
                 } catch (Exception $e) {
-                    // Skip plugins with invalid data
                     continue;
                 }
             }
@@ -221,7 +311,6 @@ class WP_Hook_Profiler_Plugin_Detector {
                 return $plugin_data['Name'];
             }
             
-            // Fallback to a readable name based on the plugin file
             $slug = $this->get_plugin_slug($plugin_file);
             return ucwords(str_replace(['-', '_'], ' ', $slug));
         } catch (Exception $e) {
@@ -231,11 +320,11 @@ class WP_Hook_Profiler_Plugin_Detector {
     
     private function unknown_source($file = null, $line = null) {
         return [
-            'plugin' => $file && str_contains($file,'multisite-ultimate')? 'Multisite Ultimate': 'unknown',
-            'plugin_name' => $file && str_contains($file,'multisite-ultimate')? 'multisite-ultimate.php': 'unknown',
+            'plugin'      => 'unknown',
+            'plugin_name' => 'Unknown',
             'plugin_file' => null,
-            'file' => $file,
-            'line' => $line
+            'file'        => $file,
+            'line'        => $line
         ];
     }
 }


### PR DESCRIPTION
## Summary

Fixes the profiler showing 'unknown' instead of the plugin name for hook callbacks.

Closes #3

## Root Causes

Five distinct bugs caused the 'unknown' attribution:

### 1. Symlink path mismatch (primary cause — affects LocalWP, Docker, Windows)

`ReflectionFunction::getFileName()` returns the **real** (symlink-resolved) path, while `WP_PLUGIN_DIR` may be a symlink path. On LocalWP (the reporter's environment) the plugins directory is typically a symlink, so `strpos($filename, WP_PLUGIN_DIR)` never matched.

**Fix:** Added `normalize_path()` using `realpath()`. All path comparisons now use canonical paths.

### 2. Single-file plugin matching was broken

The old code compared `$filename === $plugin_file` where `$plugin_file` is a bare relative name like `hello.php`. `$filename` from Reflection is always an absolute path — this comparison could never succeed.

**Fix:** Compare against the full absolute path `WP_PLUGIN_DIR . '/' . $plugin_file` (normalized).

### 3. Directory prefix collision (missing trailing slash)

`strpos($filename, $plugin_dir)` could match a plugin whose directory name is a prefix of another (e.g. `my-plugin` matching files in `my-plugin-pro`).

**Fix:** Append `/` to the directory before comparing.

### 4. mu-plugins incorrectly classified as WordPress Core

`is_wordpress_core()` included `WPMU_PLUGIN_DIR`, so callbacks from mu-plugins showed as "WordPress Core" instead of their actual source.

**Fix:** Extracted `match_file_to_mu_plugin()` which runs before the core check and attributes mu-plugin files to their own named source (e.g. `Akismet (MU)`).

### 5. Hardcoded `multisite-ultimate` special case

`unknown_source()` contained a hardcoded hack for one specific plugin. Removed — the general detection now handles all plugins correctly.

## Bonus Fix

`plugin_name` was missing from `callback_aggregates` in the callback wrapper, causing the Slowest Callbacks tab to show plugin slugs instead of display names. Added `plugin_name` to the aggregate record.

## Files Changed

- `inc/class-plugin-detector.php` — all five detection fixes
- `inc/class-callback-wrapper.php` — add `plugin_name` to callback aggregates

## Testing Evidence

- **Testing level:** self-assessed
- **Risk classification:** medium (plugin detection logic, no payment/auth/data-deletion paths)
- **Stability results:** N/A — no automated test suite in this repo
- **Behaviour verified:** Code review of all five bug paths; each fix directly addresses the identified mismatch. The symlink fix is the primary cause for LocalWP users.