### PR TITLE
fix: prevent OOM memory exhaustion on sites with many hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,48 @@ But it is only recommended to have it active while actively testing. Deactivate 
 - Check that JavaScript is enabled in your browser
 - Verify that AJAX requests are working (check browser console for errors)
 
-### High Memory Usage
-- The profiler stores timing data in memory during page execution
-- For sites with many hooks, consider using only when needed
-- Deactivate the plugin when not actively profiling
+### High Memory Usage / PHP Fatal: Allowed memory size exhausted
+
+The profiler collects data in PHP memory during the request. On sites with many
+plugins and hooks this can exhaust the default 256 MB limit. Several safeguards
+are built in:
+
+**Automatic memory guard** — profiling pauses automatically when PHP memory
+usage reaches 80 % of `memory_limit`. A warning banner appears in the panel
+when this happens. You can tune the threshold:
+
+```php
+// In your theme's functions.php or a mu-plugin:
+add_filter( 'wp_hook_profiler_memory_threshold', fn() => 0.70 ); // pause at 70 %
+```
+
+**Callback cap** — only the first 500 unique callback+hook pairs are tracked.
+Once the cap is reached, new callbacks are still executed and their time is
+counted in the total, but no new per-callback entry is created. A warning
+banner appears in the panel when the cap is hit. Raise it if needed:
+
+```php
+add_filter( 'wp_hook_profiler_max_callbacks', fn() => 1000 );
+```
+
+**Per-plugin hook list cap** — each plugin's hook list is capped at 100 entries
+to prevent O(hooks × plugins) memory growth. Raise it if needed:
+
+```php
+add_filter( 'wp_hook_profiler_max_hooks_per_plugin', fn() => 200 );
+```
+
+**Lazy data loading** — the profiling panel no longer embeds the full dataset
+as inline JSON on every page load. Data is fetched via AJAX only when you open
+the panel, eliminating the serialisation overhead that previously caused OOM
+errors at render time.
+
+If you still hit memory limits after tuning the filters, increase PHP's
+`memory_limit` in `php.ini` or `wp-config.php`:
+
+```php
+define( 'WP_MEMORY_LIMIT', '512M' );
+```
 
 ### Performance Impact
 - The profiler adds minimal overhead but does measure every hook

--- a/assets/profiler.css
+++ b/assets/profiler.css
@@ -307,6 +307,28 @@
     border: 1px solid #f5c6cb;
 }
 
+/* Memory / data-cap warning notice shown when profiling was paused or capped */
+.wp-hook-profiler-notice {
+    background: #fff3cd;
+    color: #664d03;
+    padding: 10px 20px;
+    margin: 0;
+    border-bottom: 1px solid #ffecb5;
+    font-size: 13px;
+}
+
+.wp-hook-profiler-notice p {
+    margin: 6px 0;
+}
+
+.wp-hook-profiler-notice code {
+    background: rgba(0, 0, 0, 0.06);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+}
+
 /* Plugin Loading Tab Styles */
 .wp-hook-profiler-file-name {
     font-family: 'Courier New', monospace;

--- a/assets/profiler.js
+++ b/assets/profiler.js
@@ -2,12 +2,12 @@ window.WP_Hook_Profiler = (function($) {
     'use strict';
     
     let profileData = null;
+    let dataLoaded = false;
     let currentSort = { column: null, direction: 'desc' };
     
     function init() {
         $(document).ready(function() {
             bindEvents();
-            profileData = window.hook_profiler_data;
         });
     }
     
@@ -53,7 +53,6 @@ window.WP_Hook_Profiler = (function($) {
     function show() {
         $('#wp-hook-profiler-panel, #wp-hook-profiler-overlay').show();
         loadProfileData();
-
     }
     
     function hide() {
@@ -64,12 +63,97 @@ window.WP_Hook_Profiler = (function($) {
         return $('#wp-hook-profiler-panel').is(':visible');
     }
     
+    /**
+     * Fetch profiling data via AJAX on first open.
+     *
+     * Previously the full dataset was serialised as inline JSON on every page
+     * load (via wp_json_encode in render_debug_panel). On sites with many hooks
+     * this could be several MB of JSON embedded in the HTML, which was the
+     * primary cause of the PHP memory exhaustion reported in issue #2.
+     *
+     * Now the data is fetched lazily — only when the panel is actually opened —
+     * and only once per page load (dataLoaded guard).
+     */
     function loadProfileData() {
-        showLoading();
+        if (dataLoaded) {
+            // Data already fetched this page load; just re-render.
+            renderProfileData();
+            return;
+        }
 
+        showLoading();
+        showError(null);
+
+        $.ajax({
+            url: wpHookProfiler.ajaxUrl,
+            type: 'POST',
+            data: {
+                action: 'wp_hook_profiler_data',
+                nonce: wpHookProfiler.nonce
+            },
+            success: function(response) {
+                if (response.success && response.data) {
+                    profileData = response.data;
+                    dataLoaded = true;
+                    renderProfileData();
+                    showMemoryWarnings();
+                } else {
+                    showError('Failed to load profiling data.');
+                    hideLoading();
+                }
+            },
+            error: function(xhr, status, error) {
+                showError('AJAX error: ' + error);
+                hideLoading();
+            }
+        });
+    }
+
+    function renderProfileData() {
         updateSummary();
         updateAllTables();
         hideLoading();
+    }
+
+    /**
+     * Show a notice in the panel when the profiler hit a memory or data cap
+     * during collection, so the user knows the data may be incomplete.
+     */
+    function showMemoryWarnings() {
+        if (!profileData) return;
+
+        const notices = [];
+
+        if (profileData.memory_paused) {
+            notices.push(
+                'Profiling was paused mid-request because PHP memory usage reached ' +
+                '80% of the memory_limit. Data shown is partial. ' +
+                'Increase memory_limit or reduce the number of active plugins to capture a full profile.'
+            );
+        }
+
+        if (profileData.callbacks_capped) {
+            notices.push(
+                'The callback limit (' + profileData.max_callbacks + ') was reached. ' +
+                'Some callbacks are not shown. Add ' +
+                '<code>add_filter(\'wp_hook_profiler_max_callbacks\', fn() => 1000);</code> ' +
+                'to your theme\'s functions.php to increase the limit.'
+            );
+        }
+
+        if (notices.length > 0) {
+            let noticeHtml = '<div class="wp-hook-profiler-notice">';
+            notices.forEach(function(msg) {
+                noticeHtml += '<p>' + msg + '</p>';
+            });
+            noticeHtml += '</div>';
+
+            // Insert after the summary bar, before the tab content.
+            const $summary = $('.wp-hook-profiler-summary');
+            if ($summary.length && !$('#wp-hook-profiler-notices').length) {
+                $summary.after('<div id="wp-hook-profiler-notices">' + noticeHtml + '</div>');
+            }
+        }
     }
     
     function showLoading() {

--- a/hook-profiler.php
+++ b/hook-profiler.php
@@ -122,9 +122,10 @@ class WP_Hook_Profiler {
             return;
         }
 
-		echo '<script>var hook_profiler_data = '.wp_json_encode($this->profiler->get_profile_data()).'</script>';
-
-        
+        // Do NOT inline the full profile data as JSON here.
+        // On sites with many hooks the serialized payload can be several MB,
+        // which is the primary cause of the PHP memory exhaustion reported in
+        // issue #2. The panel now fetches data lazily via AJAX when opened.
         include WP_HOOK_PROFILER_DIR . 'views/debug-panel.php';
     }
     

--- a/inc/class-callback-wrapper.php
+++ b/inc/class-callback-wrapper.php
@@ -9,6 +9,7 @@ class WP_Hook_Profiler_Callback_Wrapper {
     private $priority;
     private $accepted_args;
     private WP_Hook_Profiler_Engine $engine;
+
     public function __construct($original_function, $hook_name, $priority, $accepted_args, $engine) {
         $this->original_function = $original_function;
         $this->hook_name = $hook_name;
@@ -17,65 +18,85 @@ class WP_Hook_Profiler_Callback_Wrapper {
         $this->engine = $engine;
     }
     
-    public function __invoke(...$args ) {
+    public function __invoke(...$args) {
 
         $callback_name = $this->engine->get_callback_name($this->original_function);
-        $plugin_info = $this->engine->get_plugin_info_safe($this->original_function);
-        $callback_key = $callback_name . '|' . $this->hook_name;
-        
+        $callback_key  = $callback_name . '|' . $this->hook_name;
+        $track_metrics = true;
+
         if (!isset($this->engine->callback_aggregates[$callback_key])) {
-            $this->engine->callback_aggregates[$callback_key] = [
-                'hook'          => $this->hook_name,
-                'callback'      => $callback_name,
-                'plugin'        => $plugin_info['plugin'],
-                'plugin_name'   => $plugin_info['plugin_name'],
-                'source_file'   => $plugin_info['file'],
-                'total_time'    => 0,
-                'call_count'    => 0,
-                'average_time'  => 0,
-                'priority'      => $this->priority,
-                'accepted_args' => $this->accepted_args
-            ];
+            // Only allocate a new aggregate entry when below the cap.
+            // Once capped, we still execute the callback and accumulate
+            // total_execution_time, but we stop creating new entries to
+            // prevent unbounded memory growth on sites with many hooks.
+            if ($this->engine->is_callbacks_cap_reached()) {
+                $track_metrics = false;
+            } else {
+                $plugin_info = $this->engine->get_plugin_info_safe($this->original_function);
+                $this->engine->callback_aggregates[$callback_key] = [
+                    'hook'          => $this->hook_name,
+                    'callback'      => $callback_name,
+                    'plugin'        => $plugin_info['plugin'],
+                    'plugin_name'   => $plugin_info['plugin_name'],
+                    'source_file'   => $plugin_info['file'],
+                    'total_time'    => 0,
+                    'call_count'    => 0,
+                    'average_time'  => 0,
+                    'priority'      => $this->priority,
+                    'accepted_args' => $this->accepted_args,
+                ];
+            }
         }
+
         $start = hrtime(true);
 
 		$original_function = $this->original_function;
 		$result = $original_function(...$args);
+
         $end = hrtime(true);
-        $eta = $end - $start;
-        $eta /= 1e+6; // nanoseconds to milliseconds
+        $eta = ($end - $start) / 1e+6; // nanoseconds to milliseconds
         
         if (is_finite($eta) && $eta >= 0) {
-            $this->engine->callback_aggregates[$callback_key]['total_time'] += $eta;
-            $this->engine->callback_aggregates[$callback_key]['call_count']++;
+            // Always accumulate total execution time regardless of cap.
             $this->engine->total_execution_time += $eta;
-            
-            if ($this->engine->callback_aggregates[$callback_key]['call_count'] > 0) {
-                $this->engine->callback_aggregates[$callback_key]['average_time'] = 
-                    $this->engine->callback_aggregates[$callback_key]['total_time'] / 
-                    $this->engine->callback_aggregates[$callback_key]['call_count'];
+
+            if ($track_metrics && isset($this->engine->callback_aggregates[$callback_key])) {
+                $this->engine->callback_aggregates[$callback_key]['total_time'] += $eta;
+                $this->engine->callback_aggregates[$callback_key]['call_count']++;
+                $count = $this->engine->callback_aggregates[$callback_key]['call_count'];
+                if ($count > 0) {
+                    $this->engine->callback_aggregates[$callback_key]['average_time'] =
+                        $this->engine->callback_aggregates[$callback_key]['total_time'] / $count;
+                }
+
+                // Update plugin totals.
+                $plugin_key = $this->engine->callback_aggregates[$callback_key]['plugin'];
+
+                if (!isset($this->engine->timing_data[$plugin_key])) {
+                    // plugin_info was already resolved when creating the aggregate entry above.
+                    // Re-use the stored plugin name from the aggregate to avoid a second lookup.
+                    $this->engine->timing_data[$plugin_key] = [
+                        'total_time'     => 0,
+                        'hook_count'     => 0,
+                        'callback_count' => 0,
+                        'hooks'          => [],
+                        'plugin_name'    => $this->engine->callback_aggregates[$callback_key]['plugin_name'],
+                        'plugin_file'    => isset($plugin_info) ? $plugin_info['plugin_file'] : null,
+                    ];
+                }
+
+                $this->engine->timing_data[$plugin_key]['total_time']     += $eta;
+                $this->engine->timing_data[$plugin_key]['callback_count'] ++;
+
+                // Cap the per-plugin hooks list to prevent O(hooks × plugins) growth.
+                if (
+                    !in_array($this->hook_name, $this->engine->timing_data[$plugin_key]['hooks'], true) &&
+                    !$this->engine->is_hooks_per_plugin_cap_reached($plugin_key)
+                ) {
+                    $this->engine->timing_data[$plugin_key]['hooks'][]  = $this->hook_name;
+                    $this->engine->timing_data[$plugin_key]['hook_count']++;
+                }
             }
-        }
-        
-        // Update plugin totals
-        $plugin_key = $plugin_info['plugin'];
-        if (!isset($this->engine->timing_data[$plugin_key])) {
-            $this->engine->timing_data[$plugin_key] = [
-                'total_time' => 0,
-                'hook_count' => 0,
-                'callback_count' => 0,
-                'hooks' => [],
-                'plugin_name' => $plugin_info['plugin_name'],
-                'plugin_file' => $plugin_info['plugin_file']
-            ];
-        }
-        
-        $this->engine->timing_data[$plugin_key]['total_time'] += $eta;
-        $this->engine->timing_data[$plugin_key]['callback_count']++;
-        
-        if (!in_array($this->hook_name, $this->engine->timing_data[$plugin_key]['hooks'])) {
-            $this->engine->timing_data[$plugin_key]['hooks'][] = $this->hook_name;
-            $this->engine->timing_data[$plugin_key]['hook_count']++;
         }
         
         return $result;

--- a/inc/class-hook-profiler-engine.php
+++ b/inc/class-hook-profiler-engine.php
@@ -14,10 +14,47 @@ class WP_Hook_Profiler_Engine {
     private $hook_depth = 0;
     private $max_hook_depth = 500;
 
+    /**
+     * Maximum number of unique callback+hook pairs to track.
+     * Prevents unbounded growth of callback_aggregates on sites with many hooks.
+     * Configurable via the 'wp_hook_profiler_max_callbacks' filter.
+     */
+    private $max_callbacks = 500;
+
+    /**
+     * Maximum number of unique hook names stored per plugin in timing_data['hooks'].
+     * Prevents O(hooks × plugins) memory growth on sites with many hooks/plugins.
+     * Configurable via the 'wp_hook_profiler_max_hooks_per_plugin' filter.
+     */
+    private $max_hooks_per_plugin = 100;
+
+    /**
+     * Memory usage threshold (fraction of PHP memory_limit) at which profiling
+     * is automatically paused to prevent OOM. E.g. 0.80 = pause at 80% usage.
+     * Configurable via the 'wp_hook_profiler_memory_threshold' filter.
+     */
+    private $memory_threshold = 0.80;
+
+    /**
+     * Whether profiling was paused due to memory pressure.
+     */
+    public $memory_paused = false;
+
+    /**
+     * PHP memory limit in bytes (resolved once at construction time).
+     */
+    private $php_memory_limit = 0;
+
     public function __construct() {
         require_once WP_HOOK_PROFILER_DIR . 'inc/class-plugin-detector.php';
         require_once WP_HOOK_PROFILER_DIR . 'inc/class-callback-wrapper.php';
         $this->plugin_detector = new WP_Hook_Profiler_Plugin_Detector();
+        $this->php_memory_limit = $this->resolve_memory_limit();
+
+        // Allow site owners to tune limits without editing source.
+        $this->max_callbacks        = (int) apply_filters( 'wp_hook_profiler_max_callbacks',        $this->max_callbacks );
+        $this->max_hooks_per_plugin = (int) apply_filters( 'wp_hook_profiler_max_hooks_per_plugin', $this->max_hooks_per_plugin );
+        $this->memory_threshold     = (float) apply_filters( 'wp_hook_profiler_memory_threshold',   $this->memory_threshold );
     }
     
     public function start_profiling() {
@@ -36,6 +73,12 @@ class WP_Hook_Profiler_Engine {
         }
 
         if ($this->recursion_guard) {
+            return;
+        }
+
+        // Pause profiling if memory usage is approaching the PHP limit.
+        if ($this->is_memory_critical()) {
+            $this->memory_paused = true;
             return;
         }
         
@@ -91,6 +134,43 @@ class WP_Hook_Profiler_Engine {
 			}
 		}
     }
+
+    /**
+     * Returns true when memory usage has exceeded the configured threshold.
+     * Uses a fast integer comparison; no string parsing at call time.
+     */
+    private function is_memory_critical() {
+        if ($this->php_memory_limit <= 0) {
+            return false;
+        }
+        return memory_get_usage(true) >= (int) ($this->php_memory_limit * $this->memory_threshold);
+    }
+
+    /**
+     * Resolve the PHP memory_limit ini value to bytes.
+     * Returns 0 if the limit is -1 (unlimited) or cannot be parsed.
+     */
+    private function resolve_memory_limit() {
+        $raw = ini_get('memory_limit');
+        if ($raw === false || $raw === '' || $raw === '-1') {
+            return 0;
+        }
+        $raw   = trim($raw);
+        $value = (int) $raw;
+        $unit  = strtolower(substr($raw, -1));
+        switch ($unit) {
+            case 'g':
+                $value *= 1024 * 1024 * 1024;
+                break;
+            case 'm':
+                $value *= 1024 * 1024;
+                break;
+            case 'k':
+                $value *= 1024;
+                break;
+        }
+        return $value;
+    }
     
     
     public function get_plugin_info_safe($callback) {
@@ -135,6 +215,25 @@ class WP_Hook_Profiler_Engine {
     public function get_callback_reflection($callback) {
         return $this->plugin_detector->get_callback_reflection($callback);
     }
+
+    /**
+     * Returns true when the callback_aggregates map has reached its cap.
+     * Called by WP_Hook_Profiler_Callback_Wrapper before creating a new entry.
+     */
+    public function is_callbacks_cap_reached() {
+        return count($this->callback_aggregates) >= $this->max_callbacks;
+    }
+
+    /**
+     * Returns true when the hooks list for a given plugin has reached its cap.
+     * Called by WP_Hook_Profiler_Callback_Wrapper before appending a hook name.
+     */
+    public function is_hooks_per_plugin_cap_reached($plugin_key) {
+        if (!isset($this->timing_data[$plugin_key])) {
+            return false;
+        }
+        return count($this->timing_data[$plugin_key]['hooks']) >= $this->max_hooks_per_plugin;
+    }
     
     public function get_profile_data() {
         uasort($this->timing_data, function($a, $b) {
@@ -151,13 +250,29 @@ class WP_Hook_Profiler_Engine {
         if (function_exists('wp_hook_profiler_get_timing_data')) {
             $plugin_loading_data = wp_hook_profiler_get_timing_data();
         }
+
+        // Strip the hooks array from plugin data before returning — it can be
+        // very large and is not needed by the UI (the callbacks tab covers it).
+        $plugins_summary = [];
+        foreach ($this->timing_data as $key => $data) {
+            $plugins_summary[$key] = [
+                'total_time'     => $data['total_time'],
+                'hook_count'     => $data['hook_count'],
+                'callback_count' => $data['callback_count'],
+                'plugin_name'    => $data['plugin_name'],
+                'plugin_file'    => $data['plugin_file'],
+            ];
+        }
         
         return [
-            'plugins' => $this->timing_data,
-            'callbacks' => array_slice($callback_data, 0, 150),
-            'plugin_loading' => $plugin_loading_data,
-            'total_hooks' => $this->hook_count,
+            'plugins'           => $plugins_summary,
+            'callbacks'         => array_slice($callback_data, 0, 150),
+            'plugin_loading'    => $plugin_loading_data,
+            'total_hooks'       => $this->hook_count,
             'total_execution_time' => $this->total_execution_time,
+            'memory_paused'     => $this->memory_paused,
+            'callbacks_capped'  => count($this->callback_aggregates) >= $this->max_callbacks,
+            'max_callbacks'     => $this->max_callbacks,
         ];
     }
     


### PR DESCRIPTION
## Summary

Fixes the PHP Fatal: Allowed memory size exhausted error reported in issue #2.

Five root causes were identified and fixed:

### 1. Inline JSON dump removed from `render_debug_panel()`

The full profile dataset was serialised via `wp_json_encode()` and embedded as a `<script>` tag on **every page load**. On sites with many hooks this payload could be several MB, causing the PHP OOM at render time — before the user even opened the panel.

Data is now fetched lazily via AJAX only when the panel is opened. A `dataLoaded` guard prevents duplicate requests on subsequent opens.

### 2. `callback_aggregates` cap enforced at collection time

Previously only the final `get_profile_data()` return was sliced to 150 items, but the in-memory map grew without bound throughout the request. A new `max_callbacks` limit (default 500) stops new entries being created once the cap is reached. Existing entries continue to accumulate timing data; `total_execution_time` is always accurate.

```php
// Raise the cap if needed:
add_filter( 'wp_hook_profiler_max_callbacks', fn() => 1000 );
```

### 3. Per-plugin hooks array capped

`timing_data[$plugin]['hooks']` was an ever-growing array of every unique hook name seen for that plugin, causing O(hooks × plugins) memory growth. Capped at `max_hooks_per_plugin` (default 100).

```php
add_filter( 'wp_hook_profiler_max_hooks_per_plugin', fn() => 200 );
```

### 4. Proactive memory guard

`on_hook_start()` now checks `memory_get_usage(true)` against a configurable fraction of `memory_limit` (default 80%) and pauses profiling if the threshold is exceeded. A `memory_paused` flag is returned in `get_profile_data()` and shown as a warning banner in the UI.

```php
add_filter( 'wp_hook_profiler_memory_threshold', fn() => 0.70 );
```

### 5. `plugins` summary strips `hooks` array before returning

`get_profile_data()` now returns a `plugins_summary` that omits the `hooks` array from each plugin entry. The UI does not use it and it was the largest contributor to the serialised payload size.

## UI changes

- Warning banners shown when `memory_paused` or `callbacks_capped` so users know the data is partial and how to tune the limits.
- Panel now shows a loading spinner while the AJAX fetch completes (was instant before since data was inline).

## Files changed

- `inc/class-hook-profiler-engine.php` — memory guard, caps, filter hooks, summary stripping
- `inc/class-callback-wrapper.php` — cap enforcement at collection time, hooks-per-plugin cap
- `hook-profiler.php` — removed inline JSON dump from `render_debug_panel()`
- `assets/profiler.js` — lazy AJAX load, `dataLoaded` guard, memory/cap warning banners
- `assets/profiler.css` — warning notice styles
- `README.md` — troubleshooting section updated with filter hook examples

Closes #2