### PR TITLE
chore: mark tested up to WordPress 7.1

### DIFF
--- a/hook-profiler.php
+++ b/hook-profiler.php
@@ -9,7 +9,6 @@
  * License: GPL v2 or later
  * Network: true
  * Requires at least: 5.0
- * Tested up to: 7.1
  * Requires PHP: 7.4
  */
 

--- a/hook-profiler.php
+++ b/hook-profiler.php
@@ -9,7 +9,7 @@
  * License: GPL v2 or later
  * Network: true
  * Requires at least: 5.0
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: daveshine
 Tags: performance, profiling, hooks, debugging, developer
 Requires at least: 5.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.2.0
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

- Keeps `Tested up to: 7.1` exclusively in each package `readme.txt`.
- Removes the field from actual first-party plugin entry PHP headers.
- Adds a concise package readme when one was missing.

## Verification

- `php -l` passes for every changed plugin entry file.
- `git diff --check` passes.
- Each applicable `readme.txt` declares `Tested up to: 7.1`.
- No actual first-party plugin entry header retains `Tested up to`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin’s stated compatibility to support WordPress 7.1.
  * Aligned compatibility information across the plugin metadata and readme.
  * Removed the outdated “Tested up to” version declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->